### PR TITLE
Fix unsolicited provider traffic on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Release and engineering notes, newest first.
 
+## v0.3.3 (2026-08-19) — No unsolicited provider traffic
+
+### Fixed
+
+- Opening Argus or returning to Chat no longer sends an automatic health completion to the
+  configured LLM provider. Network access now starts only after an explicit connection check, a
+  user compile request, or an approved generative action.
+- A compile that exceeds the 65-second budget is reported as a timeout instead of being masked by
+  the generic "AI service unreachable" banner.
+
+### Verification
+
+- Added regression coverage proving that `ChatViewModel` performs zero health calls at cold start
+  while the explicit connection check still performs exactly one.
+- Added virtual-time coverage for the 65-second compile timeout and its non-misleading UI state.
+
 ## v0.3.2 (2026-08-18) — F-Droid review fixes
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Argus is a Tasker-class Android automation app where the LLM is the *compiler*, 
 
 > The app UI is bilingual (English/Italian, follows the system language).
 
-> **Privacy & license at a glance.** Argus operates **no project backend or account service** and includes no telemetry or analytics. It contacts only the LLM provider or self-hosted bridge that you explicitly configure. Rules, logs and API keys stay **on your device** (keys encrypted; the audit log records outcomes with no personal content). Argus is **free software under [GPL-3.0](LICENSE)**: you may study, modify and share it, but any derivative must stay open under the same license.
+> **Privacy & license at a glance.** Argus operates **no project backend or account service** and includes no telemetry or analytics. It contacts only the LLM provider or self-hosted bridge that you explicitly configure, and never probes it automatically on app start: network access begins with an explicit connection check, a compile request, or an approved generative action. Rules, logs and API keys stay **on your device** (keys encrypted; the audit log records outcomes with no personal content). Argus is **free software under [GPL-3.0](LICENSE)**: you may study, modify and share it, but any derivative must stay open under the same license.
 
 ---
 
@@ -293,8 +293,8 @@ but the production executor rejects them and the capability manifest marks them 
 To sign your own release: create `keystore.properties` in the root (`storeFile`, `storePassword`, `keyAlias`, `keyPassword`) — the file and the keystores are gitignored and must never be committed. Official signed APKs are on the [GitHub Releases](https://github.com/JackRushante/argus/releases).
 
 Installation: download the APK matching your device from the latest GitHub release and sideload it
-(`adb install` or APK transfer). Most current Android phones use the `arm64-v8a` asset (for v0.3.2,
-`argus-902.apk`); the release notes map every filename to its ABI. The F-Droid submission is still
+(`adb install` or APK transfer). Most current Android phones use the `arm64-v8a` asset (for v0.3.3,
+`argus-1002.apk`); the release notes map every filename to its ABI. The F-Droid submission is still
 under review; do not assume it is available in the official client until the metadata merge request
 is merged. There is no Play Store distribution. On first launch the onboarding walks you through the
 LLM provider and permissions.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "dev.argus"
         minSdk = 30
         targetSdk = 36
-        versionCode = 9
-        versionName = "0.3.2"
+        versionCode = 10
+        versionName = "0.3.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {

--- a/app/src/main/kotlin/dev/argus/nav/ArgusNavHost.kt
+++ b/app/src/main/kotlin/dev/argus/nav/ArgusNavHost.kt
@@ -167,8 +167,6 @@ fun ArgusNavHost() {
                 popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
                 launchSingleTop = true
             }
-        } else if (onboardingCompleted && currentBaseRoute == Routes.CHAT) {
-            chatViewModel.refreshHealth()
         }
     }
     var unreadChat by rememberSaveable { mutableStateOf(false) }

--- a/automation-android/src/main/kotlin/dev/argus/automation/vm/ChatViewModel.kt
+++ b/automation-android/src/main/kotlin/dev/argus/automation/vm/ChatViewModel.kt
@@ -116,7 +116,6 @@ class ChatViewModel @Inject constructor(
                     }
                 }
         }
-        refreshHealth()
     }
 
     fun onInputChange(text: String) {
@@ -295,7 +294,7 @@ class ChatViewModel @Inject constructor(
             } catch (_: kotlinx.coroutines.TimeoutCancellationException) {
                 if (generation == requestGeneration) {
                     mutableState.update {
-                        it.copy(brainReachable = false, error = ChatError.Timeout)
+                        it.copy(brainReachable = null, error = ChatError.Timeout)
                     }
                 }
             } catch (error: CancellationException) {
@@ -417,8 +416,13 @@ class ChatViewModel @Inject constructor(
         mutableState.update {
             it.copy(
                 brainReachable = when (kind) {
-                    BridgeErrorKind.CONFIGURATION, BridgeErrorKind.AUTH -> null
-                    else -> false
+                    BridgeErrorKind.CONFIGURATION,
+                    BridgeErrorKind.AUTH,
+                    BridgeErrorKind.TIMEOUT -> null
+                    BridgeErrorKind.NETWORK, BridgeErrorKind.HTTP -> false
+                    BridgeErrorKind.PROTOCOL,
+                    BridgeErrorKind.RATE_LIMIT,
+                    BridgeErrorKind.BUDGET -> true
                 },
                 error = when (kind) {
                     BridgeErrorKind.TIMEOUT -> ChatError.Timeout

--- a/automation-android/src/test/kotlin/dev/argus/automation/vm/ChatViewModelTest.kt
+++ b/automation-android/src/test/kotlin/dev/argus/automation/vm/ChatViewModelTest.kt
@@ -9,9 +9,13 @@ import dev.argus.automation.DeviceStateSnapshotProvider
 import dev.argus.automation.apps.EmptyInstalledAppResolver
 import dev.argus.automation.apps.InstalledAppCandidate
 import dev.argus.automation.apps.InstalledAppResolver
+import dev.argus.brain.AgentTransport
 import dev.argus.brain.ProviderConfig
 import dev.argus.brain.ProviderConfigStore
 import dev.argus.brain.ProviderId
+import dev.argus.brain.TransportFactory
+import dev.argus.brain.TransportHealth
+import dev.argus.engine.brain.ActResult
 import dev.argus.engine.brain.Brain
 import dev.argus.engine.brain.CapabilityManifest
 import dev.argus.engine.brain.CapabilityProbe
@@ -35,6 +39,7 @@ import dev.argus.engine.runtime.AutomationStore
 import dev.argus.engine.runtime.DeviceState
 import dev.argus.engine.runtime.FireClaimRequest
 import dev.argus.engine.runtime.FireClaimResult
+import dev.argus.engine.runtime.FireContext
 import dev.argus.engine.runtime.FirePolicySnapshot
 import dev.argus.engine.runtime.FirePolicySnapshotProvider
 import dev.argus.engine.safety.ApprovalService
@@ -48,6 +53,7 @@ import dev.argus.engine.safety.DraftWriteResult
 import dev.argus.engine.safety.NewDraft
 import dev.argus.engine.safety.PendingDraft
 import dev.argus.ui.model.ChatItem
+import dev.argus.ui.model.ChatError
 import dev.argus.ui.presentation.RenderLanguage
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -57,6 +63,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -80,6 +87,52 @@ class ChatViewModelTest {
     @AfterEach
     fun tearDown() {
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `cold start does not contact the configured brain until health is requested`() =
+        runTest(dispatcher) {
+            val transport = CountingHealthTransport()
+            val configuration = ViewModelBridgeConfiguration()
+            val configuredBridge = ConfiguredBridgeBrain(
+                configuration = configuration,
+                privacyAccepted = { true },
+                factory = TransportFactory { transport },
+                elapsedRealtimeMillis = { 0L },
+            )
+            val viewModel = chatViewModel(
+                brain = QueuedBrain(),
+                configuredBridge = configuredBridge,
+            )
+
+            runCurrent()
+
+            assertEquals(0, transport.healthCalls)
+            assertEquals(null, viewModel.state.value.brainReachable)
+
+            viewModel.refreshHealth()
+            runCurrent()
+
+            assertEquals(1, transport.healthCalls)
+            assertEquals(true, viewModel.state.value.brainReachable)
+        }
+
+    @Test
+    fun `compile timeout is shown as timeout instead of unreachable`() = runTest(dispatcher) {
+        val brain = QueuedBrain()
+        val viewModel = chatViewModel(brain)
+
+        viewModel.onInputChange("slow local model")
+        viewModel.onSend()
+        runCurrent()
+        brain.removeFirst()
+
+        advanceTimeBy(65_001L)
+        runCurrent()
+
+        assertEquals(ChatError.Timeout, viewModel.state.value.error)
+        assertEquals(null, viewModel.state.value.brainReachable)
+        assertFalse(viewModel.state.value.sending)
     }
 
     @Test
@@ -326,6 +379,7 @@ class ChatViewModelTest {
         whitelist: ContactWhitelistStore = ViewModelWhitelistStore(),
         language: RenderLanguage = RenderLanguage.IT,
         installedApps: InstalledAppResolver = EmptyInstalledAppResolver,
+        configuredBridge: ConfiguredBridgeBrain? = null,
     ): ChatViewModel {
         val automations = ViewModelAutomationStore()
         val drafts = ViewModelDraftRepository()
@@ -357,7 +411,7 @@ class ChatViewModelTest {
         val configuration = ViewModelBridgeConfiguration()
         return ChatViewModel(
             brain = brain,
-            configuredBridge = ConfiguredBridgeBrain(
+            configuredBridge = configuredBridge ?: ConfiguredBridgeBrain(
                 configuration = configuration,
                 privacyAccepted = { true },
                 elapsedRealtimeMillis = { 0L },
@@ -386,6 +440,35 @@ class ChatViewModelTest {
             unavailableTools = emptyMap(),
             whitelistedContacts = emptyList(),
         )
+    }
+}
+
+private class CountingHealthTransport : AgentTransport {
+    override val providerId: ProviderId = ProviderId.HERMES
+    var healthCalls: Int = 0
+        private set
+
+    override suspend fun compile(
+        message: String,
+        manifest: CapabilityManifest,
+        state: DeviceState,
+    ): CompileResult = error("compile must not run during a health-only test")
+
+    override suspend fun act(
+        context: FireContext,
+        goal: String,
+        contextSources: List<String>,
+        allowedTools: List<String>,
+    ): ActResult = error("act must not run during a health-only test")
+
+    override suspend fun actV2(context: FireContext, action: Action.InvokeLlmV2): ActResult =
+        error("actV2 must not run during a health-only test")
+
+    override suspend fun health(): TransportHealth {
+        healthCalls += 1
+        return object : TransportHealth {
+            override val model: String = "test-model"
+        }
     }
 }
 

--- a/docs/fdroid/PUBLISHING.md
+++ b/docs/fdroid/PUBLISHING.md
@@ -30,12 +30,12 @@ URL cannot be built yet.
 |---|---|
 | applicationId | `dev.argus` |
 | metadata file | `metadata/dev.argus.yml` |
-| version | `0.3.2` / base versionCode `9` (ABI split → 901/902/903/904) |
-| tag (v-prefixed) | `v0.3.2` |
+| version | `0.3.3` / base versionCode `10` (ABI split → 1001/1002/1003/1004) |
+| tag (v-prefixed) | `v0.3.3` |
 | build commit (full hash) | `23d86cf0b37aaa6a7ed25481b726c5a9860fd460` |
 | signing cert SHA-256 | `4c09633e64cf9876b0da682f5f259383af8d22742aadd93ef273b9f2c73cca6b` |
-| F-Droid release assets | `argus-901.apk` … `argus-904.apk` (pattern `argus-%c.apk`) |
-| direct-download asset | none for v0.3.2; use the matching per-ABI APK (`argus-902.apk` for arm64-v8a) |
+| F-Droid release assets | `argus-1001.apk` … `argus-1004.apk` (pattern `argus-%c.apk`) |
+| direct-download asset | none for v0.3.3; use the matching per-ABI APK (`argus-1002.apk` for arm64-v8a) |
 | License (SPDX) | `GPL-3.0-only` |
 
 ### Reproducibility: baseline profile dropped (v0.2.4)
@@ -65,9 +65,9 @@ ABI. Mechanics:
 
 - `app/build.gradle.kts`: `splits.abi { isUniversalApk = false; include(...) }`, and
   a per-output `versionCode = 100 * base + {armeabi-v7a:1, arm64-v8a:2, x86:3, x86_64:4}`
-  → for the current base code 9: 901/902/903/904. A `-PargusAbi=<abi>` property restricts the build
+  → for the current base code 10: 1001/1002/1003/1004. A `-PargusAbi=<abi>` property restricts the build
   to a single split so F-Droid can build each ABI as its own build block byte-for-byte.
-- Recipe: **one `Builds:` block per ABI** (for v0.3.2: versionCode 901-904, each with
+- Recipe: **one `Builds:` block per ABI** (for v0.3.3: versionCode 1001-1004, each with
   `gradleprops: [argusAbi=<abi>]`), plus top-level `VercodeOperation: [100*%c+n]` so
   autoupdate generates the four codes for future tags. `CurrentVersionCode` is the
   highest split code.
@@ -109,11 +109,11 @@ apksigner verify --print-certs app-release.apk | grep -i SHA-256
 
 ## 2. GitHub release
 
-- Tag must be **v-prefixed** (`v0.3.2`) so the `Binaries` URL `.../v%v/...` resolves.
-- The four F-Droid assets must match `argus-%c.apk` exactly (`argus-901.apk` through
-  `argus-904.apk` for v0.3.2).
+- Tag must be **v-prefixed** (`v0.3.3`) so the `Binaries` URL `.../v%v/...` resolves.
+- The four F-Droid assets must match `argus-%c.apk` exactly (`argus-1001.apk` through
+  `argus-1004.apk` for v0.3.3).
 - The release must target the exact commit pinned by every recipe block.
-- v0.3.2 intentionally publishes no universal APK. If one is added in a future release,
+- v0.3.3 intentionally publishes no universal APK. If one is added in a future release,
   its name must not match `argus-%c.apk`; F-Droid intentionally ignores it.
 
 ## 3. The recipe (`metadata/dev.argus.yml`)

--- a/fastlane/metadata/android/en-US/changelogs/1001.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1001.txt
@@ -1,0 +1,1 @@
+0.3.3 removes the automatic LLM health request on app and Chat startup. The configured provider is contacted only for an explicit connection check, a compile request, or an approved generative action. Compile requests that exceed the 65-second budget now show an accurate timeout instead of the generic unreachable-service banner.

--- a/fastlane/metadata/android/en-US/changelogs/1002.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1002.txt
@@ -1,0 +1,1 @@
+0.3.3 removes the automatic LLM health request on app and Chat startup. The configured provider is contacted only for an explicit connection check, a compile request, or an approved generative action. Compile requests that exceed the 65-second budget now show an accurate timeout instead of the generic unreachable-service banner.

--- a/fastlane/metadata/android/en-US/changelogs/1003.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1003.txt
@@ -1,0 +1,1 @@
+0.3.3 removes the automatic LLM health request on app and Chat startup. The configured provider is contacted only for an explicit connection check, a compile request, or an approved generative action. Compile requests that exceed the 65-second budget now show an accurate timeout instead of the generic unreachable-service banner.

--- a/fastlane/metadata/android/en-US/changelogs/1004.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1004.txt
@@ -1,0 +1,1 @@
+0.3.3 removes the automatic LLM health request on app and Chat startup. The configured provider is contacted only for an explicit connection check, a compile request, or an approved generative action. Compile requests that exceed the 65-second budget now show an accurate timeout instead of the generic unreachable-service banner.

--- a/fastlane/metadata/android/it/changelogs/1001.txt
+++ b/fastlane/metadata/android/it/changelogs/1001.txt
@@ -1,0 +1,1 @@
+La 0.3.3 rimuove il controllo LLM automatico all'avvio dell'app e della Chat. Il provider configurato viene contattato solo per un test connessione esplicito, una richiesta di compilazione o un'azione generativa approvata. Le compilazioni oltre il limite di 65 secondi ora mostrano correttamente un timeout invece del generico avviso di servizio irraggiungibile.

--- a/fastlane/metadata/android/it/changelogs/1002.txt
+++ b/fastlane/metadata/android/it/changelogs/1002.txt
@@ -1,0 +1,1 @@
+La 0.3.3 rimuove il controllo LLM automatico all'avvio dell'app e della Chat. Il provider configurato viene contattato solo per un test connessione esplicito, una richiesta di compilazione o un'azione generativa approvata. Le compilazioni oltre il limite di 65 secondi ora mostrano correttamente un timeout invece del generico avviso di servizio irraggiungibile.

--- a/fastlane/metadata/android/it/changelogs/1003.txt
+++ b/fastlane/metadata/android/it/changelogs/1003.txt
@@ -1,0 +1,1 @@
+La 0.3.3 rimuove il controllo LLM automatico all'avvio dell'app e della Chat. Il provider configurato viene contattato solo per un test connessione esplicito, una richiesta di compilazione o un'azione generativa approvata. Le compilazioni oltre il limite di 65 secondi ora mostrano correttamente un timeout invece del generico avviso di servizio irraggiungibile.

--- a/fastlane/metadata/android/it/changelogs/1004.txt
+++ b/fastlane/metadata/android/it/changelogs/1004.txt
@@ -1,0 +1,1 @@
+La 0.3.3 rimuove il controllo LLM automatico all'avvio dell'app e della Chat. Il provider configurato viene contattato solo per un test connessione esplicito, una richiesta di compilazione o un'azione generativa approvata. Le compilazioni oltre il limite di 65 secondi ora mostrano correttamente un timeout invece del generico avviso di servizio irraggiungibile.

--- a/ui/src/main/kotlin/dev/argus/ui/model/UiContracts.kt
+++ b/ui/src/main/kotlin/dev/argus/ui/model/UiContracts.kt
@@ -109,7 +109,7 @@ enum class DraftCardStatus { PROPOSED, APPROVED, REJECTED, SUPERSEDED }
 enum class NoticeKind { INFO, ERROR }
 
 sealed interface ChatError {
-    data object Timeout : ChatError                    // "Hermes non ha risposto entro 60 s. Riprova."
+    data object Timeout : ChatError                    // Il servizio AI non ha risposto entro 65 s.
     data object BridgeUnreachable : ChatError
     data class MalformedReply(val detail: String) : ChatError  // metaError dal parser: mostrare "risposta senza regola valida" + dettaglio espandibile
 }

--- a/ui/src/main/res/values-it/strings.xml
+++ b/ui/src/main/res/values-it/strings.xml
@@ -77,7 +77,7 @@
     <string name="chat_review_cta">Rivedi e approva</string>
     <string name="chat_brain_down">Servizio AI irraggiungibile</string>
     <string name="chat_retry">Riprova</string>
-    <string name="chat_error_timeout">Il servizio AI non risponde (timeout 60 s). Potrebbe essere occupato — riprova.</string>
+    <string name="chat_error_timeout">Il servizio AI non risponde (timeout 65 s). Potrebbe essere occupato — riprova.</string>
     <string name="chat_error_unreachable">Servizio AI irraggiungibile. Controlla la rete e la configurazione del provider, poi riprova.</string>
     <string name="chat_error_malformed">La risposta non conteneva una regola valida. Riprova o riformula.</string>
     <string name="chat_error_detail_show">Dettaglio tecnico</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -78,7 +78,7 @@
     <string name="chat_review_cta">Review and approve</string>
     <string name="chat_brain_down">AI service unreachable</string>
     <string name="chat_retry">Retry</string>
-    <string name="chat_error_timeout">The AI service is not responding (60 s timeout). It may be busy — try again.</string>
+    <string name="chat_error_timeout">The AI service is not responding (65 s timeout). It may be busy — try again.</string>
     <string name="chat_error_unreachable">AI service unreachable. Check the network connection and provider settings, then try again.</string>
     <string name="chat_error_malformed">The reply did not contain a valid rule. Retry or rephrase.</string>
     <string name="chat_error_detail_show">Technical detail</string>


### PR DESCRIPTION
## What changed

- Remove automatic LLM health checks from `ChatViewModel` construction and Chat navigation.
- Keep health traffic behind the explicit **Check connection** action and retry-without-a-prompt path.
- Report the 65-second compile budget as a timeout instead of masking it with the unreachable-service banner.
- Bump the release to 0.3.3 / ABI codes 1001–1004 and add GitHub/Fastlane release notes.

## Why

F-Droid review found that a configured provider received a one-token completion about four seconds after a cold start with no user interaction. That is harmless for a self-hosted endpoint but surprising and potentially billable for OpenAI, Anthropic, Gemini, or another commercial provider.

## Root cause

`ChatViewModel.init` called `refreshHealth()`, and `ArgusNavHost` called it again when entering Chat. The jobs cancelled each other, leaving one provider health completion. The timeout path also set `brainReachable=false`, so the higher-priority unreachable banner hid `ChatError.Timeout`.

## Validation

- Full Gradle `test lint assembleDebug assembleDebugAndroidTest`: passed.
- `ChatViewModelTest`: cold start performs 0 health calls; explicit check performs exactly 1.
- Virtual-time test verifies the 65-second timeout remains visible and does not mark the provider unreachable.
- Android API 36 emulator: 4/4 `ArgusNavigationInstrumentedTest` tests passed.
- Fastlane changelogs: 330 EN / 362 IT characters, below F-Droid's limit.
