### PR TITLE
docs(fdroid): record v0.3.3 recipe

### DIFF
--- a/docs/fdroid/dev.argus.yml
+++ b/docs/fdroid/dev.argus.yml
@@ -12,36 +12,36 @@ Repo: https://github.com/JackRushante/argus
 Binaries: https://github.com/JackRushante/argus/releases/download/v%v/argus-%c.apk
 
 Builds:
-  - versionName: 0.3.2
-    versionCode: 901
-    commit: 23d86cf0b37aaa6a7ed25481b726c5a9860fd460
+  - versionName: 0.3.3
+    versionCode: 1001
+    commit: 4f5140e7516b7ff4f16ef48fb775a4da32e94b8d
     subdir: app
     gradle:
       - yes
     gradleprops:
       - argusAbi=armeabi-v7a
 
-  - versionName: 0.3.2
-    versionCode: 902
-    commit: 23d86cf0b37aaa6a7ed25481b726c5a9860fd460
+  - versionName: 0.3.3
+    versionCode: 1002
+    commit: 4f5140e7516b7ff4f16ef48fb775a4da32e94b8d
     subdir: app
     gradle:
       - yes
     gradleprops:
       - argusAbi=arm64-v8a
 
-  - versionName: 0.3.2
-    versionCode: 903
-    commit: 23d86cf0b37aaa6a7ed25481b726c5a9860fd460
+  - versionName: 0.3.3
+    versionCode: 1003
+    commit: 4f5140e7516b7ff4f16ef48fb775a4da32e94b8d
     subdir: app
     gradle:
       - yes
     gradleprops:
       - argusAbi=x86
 
-  - versionName: 0.3.2
-    versionCode: 904
-    commit: 23d86cf0b37aaa6a7ed25481b726c5a9860fd460
+  - versionName: 0.3.3
+    versionCode: 1004
+    commit: 4f5140e7516b7ff4f16ef48fb775a4da32e94b8d
     subdir: app
     gradle:
       - yes
@@ -57,5 +57,5 @@ VercodeOperation:
   - 100 * %c + 2
   - 100 * %c + 3
   - 100 * %c + 4
-CurrentVersion: 0.3.2
-CurrentVersionCode: 904
+CurrentVersion: 0.3.3
+CurrentVersionCode: 1004


### PR DESCRIPTION
Updates the checked-in F-Droid recipe reference now that v0.3.3 has a final immutable commit, tag, and four published per-ABI APKs.

- replaces the v0.3.2 build blocks with v0.3.3 / versionCodes 1001–1004
- pins every build to release commit `4f5140e7516b7ff4f16ef48fb775a4da32e94b8d`
- updates CurrentVersion / CurrentVersionCode

The actual fdroiddata MR is updated separately; this keeps the project documentation in sync.